### PR TITLE
Improve gen-ca command help and docs

### DIFF
--- a/cmd/gen_ca.go
+++ b/cmd/gen_ca.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
-	"unicode"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -114,49 +112,14 @@ func newGenCACmd() *cobra.Command {
 	genCAProviderParameters(genCACmd.Flags())
 	genCAx509CertRequestParameters(genCACmd.Flags())
 
-	genCACmd.SetHelpFunc(helpText())
-
 	return genCACmd
 }
 
-func helpText() func(*cobra.Command, []string) {
-
-	fmt.Print("testing that we called custom help function")
-
-	funcs := map[string]interface{}{
-		"trimTrailingWhitespaces": func(s string) string { return strings.TrimRightFunc(s, unicode.IsSpace) },
-	}
-	helptxt := `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
-
-{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
-
-{{if gt (len .Example) 0 }}Examples:
-{{.Example}}{{end}}`
-
-	tmpl := template.New("help")
-	tmpl.Funcs(funcs)
-	tmpl = template.Must(tmpl.Parse(helptxt))
-
-	return func(cmd *cobra.Command, _ []string) {
-		cmd.Print("custom help function called here")
-		out := &bytes.Buffer{}
-		tmpl.Execute(out, cmd)
-		cmd.Println(out.String())
-	}
-}
-
 func examples() string {
-	funcs := map[string]interface{}{
-		"indent": func(spaces int, v string) string {
-			pad := strings.Repeat(" ", spaces)
-			return pad + strings.Replace(v, "\n", "\n"+pad, -1)
-		},
-	}
-
 	exampleText := `- AWS:
 
 cat <<EOF >> aws.yaml
-{{ .AWS | indent 0 }}
+{{ .AWS }}
 EOF
 getistio gen-ca --config-file aws.yaml
 
@@ -164,7 +127,7 @@ getistio gen-ca --config-file aws.yaml
 - GCP:
 
 cat <<EOF >> gcp.yaml
-{{ .GCP | indent 0 }}
+{{ .GCP }}
 EOF
 getistio gen-ca --config-file gcp.yaml`
 	aws, err := config.ExampleAWSInstance.ToYaml()
@@ -178,7 +141,6 @@ getistio gen-ca --config-file gcp.yaml`
 	}
 
 	extraTmpl := template.New("extra")
-	extraTmpl.Funcs(funcs)
 	extraHelp := template.Must(extraTmpl.Parse(exampleText))
 
 	out := &bytes.Buffer{}

--- a/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
@@ -9,6 +9,122 @@ Generates intermediate CA from different managed services such as AWS ACMPCA, GC
 getistio gen-ca [flags]
 ```
 
+#### Examples
+
+```
+- AWS:
+
+cat <<EOF >> aws.yaml
+providerName: aws-example
+disableSecretCreation: false
+providerConfig:
+  aws:
+    signingCAArn: <your ACM PCA CA ARN>
+    templateArn: arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1
+    signingAlgorithm: SHA256WITHRSA
+certificateParameters:
+  secretOptions:
+    istioCANamespace: istio-system
+    secretFilePath: ~/.getistio/secret/
+    force: false
+  caOptions:
+    certSigningRequestParams:
+      raw: []
+      rawtbscertificaterequest: []
+      rawsubjectpublickeyinfo: []
+      rawsubject: []
+      version: 0
+      signature: []
+      signaturealgorithm: 0
+      publickeyalgorithm: 0
+      publickey: null
+      subject:
+        country:
+        - US
+        organization:
+        - Istio
+        organizationalunit: []
+        locality:
+        - Sunnyvale
+        province:
+        - California
+        streetaddress: []
+        postalcode: []
+        serialnumber: ""
+        commonname: Istio CA
+        names: []
+        extranames: []
+      attributes: []
+      extensions: []
+      extraextensions: []
+      dnsnames:
+      - ca.istio.io
+      emailaddresses: []
+      ipaddresses: []
+      uris: []
+    validityDays: 3650
+    keyLength: 2048
+
+EOF
+getistio gen-ca --config-file aws.yaml
+
+
+- GCP:
+
+cat <<EOF >> gcp.yaml
+providerName: gcp-example
+disableSecretCreation: false
+providerConfig:
+  gcp:
+    casCAName: projects/{project-id}/locations/{location}/certificateAuthorities/{YourCA}
+    maxIssuerPathLen: 0
+certificateParameters:
+  secretOptions:
+    istioCANamespace: istio-system
+    secretFilePath: ~/.getistio/secret/
+    force: false
+  caOptions:
+    certSigningRequestParams:
+      raw: []
+      rawtbscertificaterequest: []
+      rawsubjectpublickeyinfo: []
+      rawsubject: []
+      version: 0
+      signature: []
+      signaturealgorithm: 0
+      publickeyalgorithm: 0
+      publickey: null
+      subject:
+        country:
+        - US
+        organization:
+        - Istio
+        organizationalunit: []
+        locality:
+        - Sunnyvale
+        province:
+        - California
+        streetaddress: []
+        postalcode: []
+        serialnumber: ""
+        commonname: Istio CA
+        names: []
+        extranames: []
+      attributes: []
+      extensions: []
+      extraextensions: []
+      dnsnames:
+      - ca.istio.io
+      emailaddresses: []
+      ipaddresses: []
+      uris: []
+    validityDays: 3650
+    keyLength: 2048
+
+EOF
+getistio gen-ca --config-file gcp.yaml
+```
+
 #### Options
 
 ```

--- a/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
@@ -15,7 +15,7 @@ getistio gen-ca [flags]
 - AWS:
 
 cat <<EOF >> aws.yaml
-providerName: aws-example
+providerName: aws
 disableSecretCreation: false
 providerConfig:
   aws:
@@ -72,7 +72,7 @@ getistio gen-ca --config-file aws.yaml
 - GCP:
 
 cat <<EOF >> gcp.yaml
-providerName: gcp-example
+providerName: gcp
 disableSecretCreation: false
 providerConfig:
   gcp:

--- a/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
@@ -26,7 +26,7 @@ certificateParameters:
   secretOptions:
     istioCANamespace: istio-system
     secretFilePath: ~/.getistio/secret/
-    force: false
+    overrideExistingCACertsSecret: false
   caOptions:
     certSigningRequestParams:
       raw: []
@@ -82,7 +82,7 @@ certificateParameters:
   secretOptions:
     istioCANamespace: istio-system
     secretFilePath: ~/.getistio/secret/
-    force: false
+    overrideExistingCACertsSecret: false
   caOptions:
     certSigningRequestParams:
       raw: []

--- a/src/cacerts/providers/aws.go
+++ b/src/cacerts/providers/aws.go
@@ -36,8 +36,8 @@ type ProviderAWS struct {
 	SigningCA   string `yaml:"signingCAArn"`
 	TemplateARN string `yaml:"templateArn"`
 	// SigningAlgorithm is the signing algorithm to be used by AWS Issue Certificate.
-	SigningAlgorithm string `yaml:"signingAlgorithm"`
-	acmpcaiface.ACMPCAAPI
+	SigningAlgorithm      string `yaml:"signingAlgorithm"`
+	acmpcaiface.ACMPCAAPI `yaml:"-"`
 }
 
 var _ ProviderInterface = &ProviderAWS{}

--- a/src/cacerts/providers/config/config.go
+++ b/src/cacerts/providers/config/config.go
@@ -80,11 +80,11 @@ type Config struct {
 	} `yaml:"providerConfig"`
 
 	// CertParameters contains all the Certificate related information.
-	CertParameters models.IssueCAOptions `yaml:"certificateParameters"`
+	CertParameters models.IssueCAOptions `yaml:"certificateParameters,omitempty"`
 }
 
 var ExampleAWSInstance = Config{
-	ProviderName:          "aws-example",
+	ProviderName:          "aws",
 	DisableSecretCreation: false,
 	ProviderConfig: struct {
 		AWSConfig *ops.ProviderAWS `yaml:"aws,omitempty"`
@@ -98,7 +98,7 @@ var ExampleAWSInstance = Config{
 }
 
 var ExampleGCPInstance = Config{
-	ProviderName:          "gcp-example",
+	ProviderName:          "gcp",
 	DisableSecretCreation: false,
 	ProviderConfig: struct {
 		AWSConfig *ops.ProviderAWS `yaml:"aws,omitempty"`

--- a/src/cacerts/providers/config/config.go
+++ b/src/cacerts/providers/config/config.go
@@ -165,9 +165,9 @@ func (c *Config) ValidationsForConfig() error {
 
 var defaultCertParams = models.IssueCAOptions{
 	SecretOptions: models.SecretOptions{
-		IstioNamespace: "istio-system",
-		SecretFilePath: "~/.getistio/secret/",
-		Force:          false,
+		IstioNamespace:               "istio-system",
+		SecretFilePath:               "~/.getistio/secret/",
+		OverrideExistingCACertSecret: false,
 	},
 	CAOptions: models.CAOptions{
 		CertRequest: x509.CertificateRequest{

--- a/src/cacerts/providers/config/config.go
+++ b/src/cacerts/providers/config/config.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -73,12 +75,39 @@ type Config struct {
 	// needed to connect to the Provider.
 	ProviderConfig struct {
 		// AWSConfig contains all the AWS related configuration
-		AWSConfig *ops.ProviderAWS `yaml:"aws"`
-		GCPConfig *ops.ProviderGCP `yaml:"gcp"`
+		AWSConfig *ops.ProviderAWS `yaml:"aws,omitempty"`
+		GCPConfig *ops.ProviderGCP `yaml:"gcp,omitempty"`
 	} `yaml:"providerConfig"`
 
 	// CertParameters contains all the Certificate related information.
 	CertParameters models.IssueCAOptions `yaml:"certificateParameters"`
+}
+
+var ExampleAWSInstance = Config{
+	ProviderName:          "aws-example",
+	DisableSecretCreation: false,
+	ProviderConfig: struct {
+		AWSConfig *ops.ProviderAWS `yaml:"aws,omitempty"`
+		GCPConfig *ops.ProviderGCP `yaml:"gcp,omitempty"`
+	}{AWSConfig: &ops.ProviderAWS{
+		SigningCA:        "<your ACM PCA CA ARN>",
+		TemplateARN:      "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1",
+		SigningAlgorithm: "SHA256WITHRSA",
+	}},
+	CertParameters: defaultCertParams,
+}
+
+var ExampleGCPInstance = Config{
+	ProviderName:          "gcp-example",
+	DisableSecretCreation: false,
+	ProviderConfig: struct {
+		AWSConfig *ops.ProviderAWS `yaml:"aws,omitempty"`
+		GCPConfig *ops.ProviderGCP `yaml:"gcp,omitempty"`
+	}{GCPConfig: &ops.ProviderGCP{
+		CASCAName:        "projects/{project-id}/locations/{location}/certificateAuthorities/{YourCA}",
+		MaxIssuerPathLen: 0,
+	}},
+	CertParameters: defaultCertParams,
 }
 
 // NewConfig returns new parsed config
@@ -110,6 +139,11 @@ func NewConfig(path string) (*Config, error) {
 	return c, nil
 }
 
+func (c *Config) ToYaml() (string, error) {
+	str, err := yaml.Marshal(c)
+	return string(str), err
+}
+
 // ValidationsForConfig validates the config before proceeding.
 func (c *Config) ValidationsForConfig() error {
 	if models.ProviderName(c.ProviderName) != models.AWS &&
@@ -127,6 +161,28 @@ func (c *Config) ValidationsForConfig() error {
 	default:
 		return fmt.Errorf("provider %s yet to be implemented", c.ProviderName)
 	}
+}
+
+var defaultCertParams = models.IssueCAOptions{
+	SecretOptions: models.SecretOptions{
+		IstioNamespace: "istio-system",
+		SecretFilePath: "~/.getistio/secret/",
+		Force:          false,
+	},
+	CAOptions: models.CAOptions{
+		CertRequest: x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName:   "Istio CA",
+				Organization: []string{"Istio"},
+				Country:      []string{"US"},
+				Province:     []string{"California"},
+				Locality:     []string{"Sunnyvale"},
+			},
+			DNSNames: []string{"ca.istio.io"},
+		},
+		ValidityDays: 3650,
+		KeyLength:    2048,
+	},
 }
 
 // SetDefaultValues sets the defaults in config struct as follows:
@@ -148,40 +204,40 @@ func (c *Config) SetDefaultValues() {
 	// Default Cert Parameters
 
 	if c.CertParameters.ValidityDays == 0 {
-		c.CertParameters.ValidityDays = 3650
+		c.CertParameters.ValidityDays = defaultCertParams.ValidityDays
 	}
 
 	if c.CertParameters.KeyLength == 0 {
-		c.CertParameters.KeyLength = 2048
+		c.CertParameters.KeyLength = defaultCertParams.KeyLength
 	}
 
 	if c.CertParameters.IstioNamespace == "" {
-		c.CertParameters.IstioNamespace = "istio-system"
+		c.CertParameters.IstioNamespace = defaultCertParams.IstioNamespace
 	}
 
 	// Default Cert Request
 	if c.CertParameters.CertRequest.Subject.CommonName == "" {
-		c.CertParameters.CertRequest.Subject.CommonName = "Istio CA"
+		c.CertParameters.CertRequest.Subject.CommonName = defaultCertParams.CertRequest.Subject.CommonName
 	}
 
 	if c.CertParameters.CertRequest.Subject.Province == nil {
-		c.CertParameters.CertRequest.Subject.Province = []string{"California"}
+		c.CertParameters.CertRequest.Subject.Province = defaultCertParams.CertRequest.Subject.Province
 	}
 
 	if c.CertParameters.CertRequest.Subject.Locality == nil {
-		c.CertParameters.CertRequest.Subject.Locality = []string{"Sunnyvale"}
+		c.CertParameters.CertRequest.Subject.Locality = defaultCertParams.CertRequest.Subject.Locality
 	}
 
 	if c.CertParameters.CertRequest.Subject.Organization == nil {
-		c.CertParameters.CertRequest.Subject.Organization = []string{"Istio"}
+		c.CertParameters.CertRequest.Subject.Organization = defaultCertParams.CertRequest.Subject.Organization
 	}
 
 	if c.CertParameters.CertRequest.Subject.Country == nil {
-		c.CertParameters.CertRequest.Subject.Country = []string{"US"}
+		c.CertParameters.CertRequest.Subject.Country = defaultCertParams.CertRequest.Subject.Country
 	}
 
 	if c.CertParameters.CertRequest.DNSNames == nil {
-		c.CertParameters.CertRequest.DNSNames = []string{"ca.istio.io"}
+		c.CertParameters.CertRequest.DNSNames = defaultCertParams.CertRequest.DNSNames
 	}
 
 }

--- a/src/cacerts/providers/gcp.go
+++ b/src/cacerts/providers/gcp.go
@@ -32,9 +32,9 @@ import (
 
 // ProviderGCP contains credentials for establishing connection to the GCP,
 type ProviderGCP struct {
-	CASCAName        string `yaml:"casCAName"`
-	MaxIssuerPathLen int32  `yaml:"maxIssuerPathLen"`
-	*privateca.CertificateAuthorityClient
+	CASCAName                             string `yaml:"casCAName"`
+	MaxIssuerPathLen                      int32  `yaml:"maxIssuerPathLen"`
+	*privateca.CertificateAuthorityClient `yaml:"-"`
 }
 
 var _ ProviderInterface = &ProviderGCP{}


### PR DESCRIPTION
Add some examples to the `gen-ca` command which print the some default config files so users have an idea of what to configure. This shows up both in the help text for the command as well as in the generated docs.

```sh
./getistio gen-ca --help
Generates intermediate CA from different managed services such as AWS ACMPCA, GCP CAS

Usage:
  getistio gen-ca [flags]

Examples:
- AWS:

cat <<EOF >> aws.yaml
providerName: aws-example
disableSecretCreation: false
providerConfig:
  aws:
    signingCAArn: <your ACM PCA CA ARN>
    templateArn: arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1
    signingAlgorithm: SHA256WITHRSA
certificateParameters:
  secretOptions:
    istioCANamespace: istio-system
    secretFilePath: ~/.getistio/secret/
    force: false
  caOptions:
    certSigningRequestParams:
      raw: []
      rawtbscertificaterequest: []
      rawsubjectpublickeyinfo: []
      rawsubject: []
      version: 0
      signature: []
      signaturealgorithm: 0
      publickeyalgorithm: 0
      publickey: null
      subject:
        country:
        - US
        organization:
        - Istio
        organizationalunit: []
        locality:
        - Sunnyvale
        province:
        - California
        streetaddress: []
        postalcode: []
        serialnumber: ""
        commonname: Istio CA
        names: []
        extranames: []
      attributes: []
      extensions: []
      extraextensions: []
      dnsnames:
      - ca.istio.io
      emailaddresses: []
      ipaddresses: []
      uris: []
    validityDays: 3650
    keyLength: 2048

EOF
getistio gen-ca --config-file aws.yaml


- GCP:

cat <<EOF >> gcp.yaml
providerName: gcp-example
disableSecretCreation: false
providerConfig:
  gcp:
    casCAName: projects/{project-id}/locations/{location}/certificateAuthorities/{YourCA}
    maxIssuerPathLen: 0
certificateParameters:
  secretOptions:
    istioCANamespace: istio-system
    secretFilePath: ~/.getistio/secret/
    force: false
  caOptions:
    certSigningRequestParams:
      raw: []
      rawtbscertificaterequest: []
      rawsubjectpublickeyinfo: []
      rawsubject: []
      version: 0
      signature: []
      signaturealgorithm: 0
      publickeyalgorithm: 0
      publickey: null
      subject:
        country:
        - US
        organization:
        - Istio
        organizationalunit: []
        locality:
        - Sunnyvale
        province:
        - California
        streetaddress: []
        postalcode: []
        serialnumber: ""
        commonname: Istio CA
        names: []
        extranames: []
      attributes: []
      extensions: []
      extraextensions: []
      dnsnames:
      - ca.istio.io
      emailaddresses: []
      ipaddresses: []
      uris: []
    validityDays: 3650
    keyLength: 2048

EOF
getistio gen-ca --config-file gcp.yaml

Flags:
      --cas-ca-name string                CAS CA Name string
      --common-name string                Common name for x509 Cert request
      --config-file string                path to config file
      --country stringArray               Country names for x509 Cert request
      --disable-secret-creation           file only, doesn't create secret
      --email stringArray                 Emails for x509 Cert request
      --force                             force flag just deletes the existing secret and creates a new one
  -h, --help                              help for gen-ca
      --istio-ca-namespace cacerts        Namespace refered for creating the cacerts secrets in
      --key-length int                    length of generated key in bits for CA
      --locality stringArray              Locality names for x509 Cert request
      --max-issuer-path-len int32         CAS CA Max Issuer Path Length
      --organization stringArray          Organization names for x509 Cert request
      --organizational-unit stringArray   OrganizationalUnit names for x509 Cert request
  -p, --provider string                   name of the provider to be used, i.e aws, gcp
      --province stringArray              Province names for x509 Cert request
      --secret-file-path string           secret-file-path flag creates the secret YAML file
      --signing-algorithm string          Signing Algorithm to be used for issuing Cert using CSR for AWS
      --signing-ca string                 signing CA ARN string
      --template-arn string               Template ARN used to be used for issuing Cert using CSR
      --validity-days int                 valid dates for subordinate CA

Global Flags:
  -c, --kubeconfig string   Kubernetes configuration file
```

Unfortunately we can't easily trim the un-used fields that get printed from the X509 cert request, but I think it's still an improvement over what we have today.