### PR TITLE
Remove auto sorting of flags, trust the flags registration order

### DIFF
--- a/cmd/config_validate.go
+++ b/cmd/config_validate.go
@@ -102,6 +102,7 @@ The error code of the found issue which is prefixed by 'IST' or 'KIA'. Please re
 	}
 
 	flags := cmd.Flags()
+	flags.SortFlags = false
 	flags.StringVarP(&flagNS, "namespace", "n", "", "namespace for config validation")
 	flags.StringVarP(&flagOutputThreshold, "output-threshold", "",
 		configvalidator.SeverityLevelInfo.Name,

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -93,6 +93,7 @@ For more information, please refer to "getistio list --help" command.
 	}
 
 	flags := cmd.Flags()
+	flags.SortFlags = false
 	flags.StringVarP(&flagVersion, "version", "", "", "Version of istioctl e.g. \"--version 1.7.4\"")
 	flags.StringVarP(&flagFlavor, "flavor", "", "", "Flavor of istioctl, e.g. \"--flavor tetrate\" or --flavor tetratefips\"")
 	flags.IntVarP(&flagFlavorVersion, "flavor-version", "", -1, "Version of the flavor, e.g. \"--version 1\"")

--- a/cmd/gen_ca.go
+++ b/cmd/gen_ca.go
@@ -109,8 +109,10 @@ func newGenCACmd() *cobra.Command {
 		},
 	}
 
-	genCAProviderParameters(genCACmd.Flags())
-	genCAx509CertRequestParameters(genCACmd.Flags())
+	flags := genCACmd.Flags()
+	flags.SortFlags = false
+	genCAProviderParameters(flags)
+	genCAx509CertRequestParameters(flags)
 
 	return genCACmd
 }

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -51,6 +51,7 @@ $ getistio prune --version 1.7.4 --flavor tetrate --flavor-version 0
 	}
 
 	flags := cmd.Flags()
+	flags.SortFlags = false
 	flags.StringVarP(&flagVersion, "version", "", "", "Version of istioctl e.g. 1.7.4")
 	flags.StringVarP(&flagFlavor, "flavor", "", "", "Flavor of istioctl, e.g. \"tetrate\" or \"tetratefips\"")
 	flags.IntVarP(&flagFlavorVersion, "flavor-version", "", -1, "Version of the flavor, e.g. 1")

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -47,6 +47,7 @@ $ getistio switch --version 1.7.4 --flavor tetrate --flavor-version=1`,
 	}
 
 	flags := cmd.Flags()
+	flags.SortFlags = false
 	flags.StringVarP(&flagVersion, "version", "", "", "Version of istioctl e.g. 1.7.4")
 	flags.StringVarP(&flagFlavor, "flavor", "", "", "Flavor of istioctl, e.g. \"tetrate\" or \"tetratefips\"")
 	flags.IntVarP(&flagFlavorVersion, "flavor-version", "", -1, "Version of the flavor, e.g. 1")

--- a/doc/en/getistio-cli/reference/getistio_config-validate/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_config-validate/_index.md
@@ -66,9 +66,9 @@ The error code of the found issue which is prefixed by 'IST' or 'KIA'. Please re
 #### Options
 
 ```
-  -h, --help                      help for config-validate
   -n, --namespace string          namespace for config validation
       --output-threshold string   severity level of analysis at which to display messages. Valid values: [Error Warning Info] (default "Info")
+  -h, --help                      help for config-validate
 ```
 
 #### Options inherited from parent commands

--- a/doc/en/getistio-cli/reference/getistio_fetch/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_fetch/_index.md
@@ -49,10 +49,10 @@ For more information, please refer to "getistio list --help" command.
 #### Options
 
 ```
+      --version string       Version of istioctl e.g. "--version 1.7.4"
       --flavor string        Flavor of istioctl, e.g. "--flavor tetrate" or --flavor tetratefips"
       --flavor-version int   Version of the flavor, e.g. "--version 1" (default -1)
   -h, --help                 help for fetch
-      --version string       Version of istioctl e.g. "--version 1.7.4"
 ```
 
 #### Options inherited from parent commands

--- a/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_gen-ca/_index.md
@@ -128,27 +128,27 @@ getistio gen-ca --config-file gcp.yaml
 #### Options
 
 ```
-      --cas-ca-name string                 CAS CA Name string
-      --common-name string                 Common name for x509 Cert request
       --config-file string                 path to config file
-      --country stringArray                Country names for x509 Cert request
       --disable-secret-creation            file only, doesn't create secret
-      --email stringArray                  Emails for x509 Cert request
-  -h, --help                               help for gen-ca
-      --istio-ca-namespace cacerts         Namespace refered for creating the cacerts secrets in
-      --key-length int                     length of generated key in bits for CA
-      --locality stringArray               Locality names for x509 Cert request
-      --max-issuer-path-len int32          CAS CA Max Issuer Path Length
-      --organization stringArray           Organization names for x509 Cert request
-      --organizational-unit stringArray    OrganizationalUnit names for x509 Cert request
-      --override-existing-ca-cert-secret   override-existing-ca-cert-secret overrides the existing secret and creates a new one
   -p, --provider string                    name of the provider to be used, i.e aws, gcp
-      --province stringArray               Province names for x509 Cert request
-      --secret-file-path string            secret-file-path flag creates the secret YAML file
-      --signing-algorithm string           Signing Algorithm to be used for issuing Cert using CSR for AWS
       --signing-ca string                  signing CA ARN string
       --template-arn string                Template ARN used to be used for issuing Cert using CSR
+      --signing-algorithm string           Signing Algorithm to be used for issuing Cert using CSR for AWS
+      --cas-ca-name string                 CAS CA Name string
+      --max-issuer-path-len int32          CAS CA Max Issuer Path Length
+      --common-name string                 Common name for x509 Cert request
+      --country stringArray                Country names for x509 Cert request
+      --province stringArray               Province names for x509 Cert request
+      --locality stringArray               Locality names for x509 Cert request
+      --organization stringArray           Organization names for x509 Cert request
+      --organizational-unit stringArray    OrganizationalUnit names for x509 Cert request
+      --email stringArray                  Emails for x509 Cert request
+      --istio-ca-namespace cacerts         Namespace refered for creating the cacerts secrets in
+      --secret-file-path string            secret-file-path flag creates the secret YAML file
+      --override-existing-ca-cert-secret   override-existing-ca-cert-secret overrides the existing secret and creates a new one
       --validity-days int                  valid dates for subordinate CA
+      --key-length int                     length of generated key in bits for CA
+  -h, --help                               help for gen-ca
 ```
 
 #### Options inherited from parent commands

--- a/doc/en/getistio-cli/reference/getistio_prune/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_prune/_index.md
@@ -23,10 +23,10 @@ $ getistio prune --version 1.7.4 --flavor tetrate --flavor-version 0
 #### Options
 
 ```
+      --version string       Version of istioctl e.g. 1.7.4
       --flavor string        Flavor of istioctl, e.g. "tetrate" or "tetratefips"
       --flavor-version int   Version of the flavor, e.g. 1 (default -1)
   -h, --help                 help for prune
-      --version string       Version of istioctl e.g. 1.7.4
 ```
 
 #### Options inherited from parent commands

--- a/doc/en/getistio-cli/reference/getistio_switch/_index.md
+++ b/doc/en/getistio-cli/reference/getistio_switch/_index.md
@@ -19,10 +19,10 @@ $ getistio switch --version 1.7.4 --flavor tetrate --flavor-version=1
 #### Options
 
 ```
+      --version string       Version of istioctl e.g. 1.7.4
       --flavor string        Flavor of istioctl, e.g. "tetrate" or "tetratefips"
       --flavor-version int   Version of the flavor, e.g. 1 (default -1)
   -h, --help                 help for switch
-      --version string       Version of istioctl e.g. 1.7.4
 ```
 
 #### Options inherited from parent commands


### PR DESCRIPTION
Cobra automatically sorts flags for commands. Typically the best way to manage order of flags is manually through the order of registration. This especially keeps contextual groupings of flags intact. 

This PR explicitly sets sorting to false. Most noticable impact can be found  for the `gen-ca` command.

Signed-off-by: Bas van Beek <bas@tobin.nl>